### PR TITLE
Add NibInstantiatable wrapper when use it in InterfaceBuilder.

### DIFF
--- a/Instantiate/Nib.swift
+++ b/Instantiate/Nib.swift
@@ -27,3 +27,38 @@ public extension NibInstantiatable where Self: UIView {
         return nib.instantiate(withOwner: nil, options: nil)[instantiateIndex] as! Self
     }
 }
+
+/// Use this protocols implementation instead of NibInstantiatable in InterfaceBuilder.
+public protocol NibInstantiatableWrapper {
+    associatedtype Wrapped: NibInstantiatable
+    var view: Wrapped { get }
+    var viewIfLoaded: Wrapped? { get }
+}
+
+public extension NibInstantiatableWrapper where Self: UIView, Wrapped: UIView {
+    var view: Wrapped {
+        return self.subviews.first as! Wrapped
+    }
+    
+    var viewIfLoaded: Wrapped? {
+        return self.subviews.first as? Wrapped
+    }
+    
+    /// Please call this method on `awakeFromNib()` and `prepareForInterfaceBuilder()` if needed.
+    func loadViewFromNib(useAutolayout: Bool) {
+        let view = Wrapped.instantiate()
+        if useAutolayout {
+            view.translatesAutoresizingMaskIntoConstraints = false
+            self.insertSubview(view, at: 0)
+            view.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
+            view.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
+            view.leftAnchor.constraint(equalTo: self.leftAnchor).isActive = true
+            view.rightAnchor.constraint(equalTo: self.rightAnchor).isActive = true
+        } else {
+            view.translatesAutoresizingMaskIntoConstraints = true
+            view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+            view.frame = self.bounds
+            self.insertSubview(view, at: 0)
+        }
+    }
+}


### PR DESCRIPTION
- [x] Check we cannot use `class NibInstantiatableWrapper<V: UIView>: UIView where V: NibInstantiatable` instead of the protocol.