### PR TITLE
Correct the interface of `bind` to conform to grammar.

### DIFF
--- a/Instantiate/Bindable.swift
+++ b/Instantiate/Bindable.swift
@@ -13,11 +13,11 @@ public protocol Bindable {
     associatedtype Parameter
     /// `bind` call after prepare user intarfaces. e.g.) `UIViewController.viewDidLoad`, `UIView.awakeFromNib`.
     /// - parameter parameter: User interface needs to some parameter(s).
-    func bind(to parameter: Parameter)
+    func bind(_ parameter: Parameter)
 }
 
 public extension Bindable where Parameter == Void {
-    func bind(to parameter: Parameter) {
+    func bind(_ parameter: Parameter) {
         
     }
 }

--- a/Instantiate/Nib.swift
+++ b/Instantiate/Nib.swift
@@ -28,7 +28,7 @@ public extension NibInstantiatable where Self: NSObject {
 public extension NibInstantiatable where Self: UIView {
     public static func instantiate(with parameter: Parameter) -> Self {
         let _self = nib.instantiate(withOwner: nil, options: nil)[instantiateIndex] as! Self
-        _self.bind(to: parameter)
+        _self.bind(parameter)
         return _self
     }
 }

--- a/Instantiate/Reusable.swift
+++ b/Instantiate/Reusable.swift
@@ -29,7 +29,7 @@ public extension UITableView {
     
     public func dequeReusableCell<C: UITableViewCell>(type: C.Type, for indexPath: IndexPath, with parameter: C.Parameter) -> C where C: Reusable, C: Bindable {
         let cell = dequeReusableCell(type: type, for: indexPath)
-        cell.bind(to: parameter)
+        cell.bind(parameter)
         return cell
     }
 }
@@ -49,7 +49,7 @@ public extension UICollectionView {
     
     public func dequeReusableCell<C: UICollectionViewCell>(type: C.Type, for indexPath: IndexPath, with parameter: C.Parameter) -> C where C: Reusable, C: Bindable {
         let cell = dequeReusableCell(type: type, for: indexPath)
-        cell.bind(to: parameter)
+        cell.bind(parameter)
         return cell
     }
 }
@@ -69,7 +69,7 @@ public extension UICollectionView {
     
     public func dequeueReusableSupplementaryView<C: UICollectionReusableView>(type: C.Type, of kind: String, for indexPath: IndexPath, with parameter: C.Parameter) -> C where C: Reusable, C: Bindable {
         let view =  dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: C.reusableIdentifier, for: indexPath) as! C
-        view.bind(to: parameter)
+        view.bind(parameter)
         return view
     }
 }

--- a/Instantiate/Storyboard.swift
+++ b/Instantiate/Storyboard.swift
@@ -42,7 +42,7 @@ public extension StoryboardInstantiatable where Self: UIViewController {
             _self = storyboard.instantiateViewController(withIdentifier: identifier) as! Self
         }
         _ = _self.view // workaround: load view before bind.
-        _self.bind(to: parameter)
+        _self.bind(parameter)
         return _self
     }
 }

--- a/InstantiateTestsResource/Resources.swift
+++ b/InstantiateTestsResource/Resources.swift
@@ -14,7 +14,7 @@ final class View: UIView, NibInstantiatable {
     typealias Parameter = UIColor
     var parameter: Parameter!
     
-    func bind(to parameter: UIColor) {
+    func bind(_ parameter: UIColor) {
         self.backgroundColor = parameter
     }
 }
@@ -22,7 +22,7 @@ final class View: UIView, NibInstantiatable {
 final class ViewController: UIViewController, StoryboardInstantiatable {
     typealias Parameter = String
     
-    func bind(to parameter: String) {
+    func bind(_ parameter: String) {
         self.label.text = parameter
     }
         
@@ -37,7 +37,7 @@ final class ViewController: UIViewController, StoryboardInstantiatable {
     typealias Wrapped = View
     @IBInspectable var color: UIColor = .white {
         didSet {
-            viewIfLoaded?.bind(to: color)
+            viewIfLoaded?.bind(color)
         }
     }
     
@@ -64,7 +64,7 @@ final class TableViewCell: UITableViewCell, Reusable, NibType, Bindable {
     typealias Parameter = Int
     @IBOutlet weak var label: UILabel!
     
-    func bind(to parameter: Int) {
+    func bind(_ parameter: Int) {
         label.text = "\(parameter)"
     }
 }
@@ -82,7 +82,7 @@ final class ViewController3: UIViewController, StoryboardInstantiatable {
         }
     }
     
-    func bind(to parameter: [Int]) {
+    func bind(_ parameter: [Int]) {
         dataSource = parameter
         tableView.reloadData()
     }
@@ -110,7 +110,7 @@ final class CollectionViewCell: UICollectionViewCell, Reusable, NibType, Bindabl
     typealias Parameter = String
     @IBOutlet weak var label: UILabel!
     
-    func bind(to parameter: String) {
+    func bind(_ parameter: String) {
         label.text = parameter
     }
 }
@@ -119,7 +119,7 @@ final class CollectionReusableView: UICollectionReusableView, Reusable, NibType,
     typealias Parameter = String
     @IBOutlet weak var label: UILabel!
     
-    func bind(to parameter: String) {
+    func bind(_ parameter: String) {
         label.text = parameter
     }
 }
@@ -138,7 +138,7 @@ final class ViewController4: UIViewController, StoryboardInstantiatable {
         }
     }
     
-    func bind(to parameter: Array<(header: String, items: [String])>) {
+    func bind(_ parameter: Array<(header: String, items: [String])>) {
         dataSource = parameter
         collectionView.reloadData()
     }


### PR DESCRIPTION
I think that "Binding some parameters to an object conforming to Bindable protocol" is correct grammatically.
So, I removed `to` from `bind(to parameter: Parameter)` protocol method.