### PR TITLE
Optional associatedtype

### DIFF
--- a/Instantiate/Bindable.swift
+++ b/Instantiate/Bindable.swift
@@ -17,7 +17,7 @@ public protocol Bindable {
 }
 
 public extension Bindable where Parameter == Void {
-    func bind(_ parameter: Parameter) {
+    func bind(_ parameter: Void) {
         
     }
 }


### PR DESCRIPTION
as is
```swift
class VC: UIViewController, StoryboardInstantiatable {
  typealias Parameter = Void // Need to define
}
```

to be 
```swift
class VC: UIViewController, StoryboardInstantiatable {
  // typealias Parameter = Void // It would be optional.
}
```