### PR TITLE
fixed InstantiateStandard's dependency version.

### DIFF
--- a/Instantiate.podspec
+++ b/Instantiate.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Instantiate'
-  s.version          = '3.0.0'
+  s.version          = '3.0.1'
   s.summary          = 'Type-safe InterfaceBuilder protocols.'
   s.description      = <<-DESC
 Storyboard and Nib is not type safe, if you use `UIStoryboard` or `UINib`, your code would be get some gloom.

--- a/InstantiateStandard.podspec
+++ b/InstantiateStandard.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'InstantiateStandard'
-  s.version          = '3.0.0'
+  s.version          = '3.0.1'
   s.summary          = 'Type-safe InterfaceBuilder protocols.'
   s.description      = <<-DESC
 Storyboard and Nib is not type safe, if you use `UIStoryboard` or `UINib`, your code would be get some gloom.
@@ -16,5 +16,5 @@ Instantiate take type-safe protocols for Storyboard and Nib. Lets' improve our c
   s.tvos.deployment_target = '9.0'
 
   s.source_files = 'Sources/InstantiateStandard/**/*'
-  s.dependency 'Instantiate', '~>2.2'
+  s.dependency 'Instantiate', '~>3.0'
 end


### PR DESCRIPTION
I submitted #33 before but we can't use v3.0.0 via CocoaPods yet.
I just fixed InstantiateStandard.podspec's `s.dependency` correctly.
